### PR TITLE
Place generated files in `$OUT_DIR`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "webidl"
 readme = "README.md"
 repository = "https://github.com/sgodwincs/webidl-rs"
 version = "0.5.0"
-exclude = ["tests/*.zip", "src/parser/grammar.rs"]
+exclude = ["tests/*.zip"]
 
 [build-dependencies]
 lalrpop = "^0.14"

--- a/build.rs
+++ b/build.rs
@@ -2,5 +2,8 @@ extern crate lalrpop;
 
 fn main() {
     println!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
-    lalrpop::process_root().unwrap();
+    lalrpop::Configuration::new()
+        .use_cargo_dir_conventions()
+        .process()
+        .unwrap();
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,9 @@
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[allow(unknown_lints)]
 #[allow(clippy)]
-mod grammar;
+mod grammar {
+    include!(concat!(env!("OUT_DIR"), "/parser/grammar.rs"));
+}
 
 /// Contains all structures related to the AST for the WebIDL grammar.
 pub mod ast;


### PR DESCRIPTION
This prevents generated files from ending up in the source directory where they may be accidentally packaged or vendored.  Closes #11.