### PR TITLE
relax dependencies on lalrpop packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ version = "0.7.0"
 exclude = ["tests/*.zip"]
 
 [build-dependencies]
-lalrpop = "0.15.1"
+lalrpop = "0.15"
 
 [dependencies]
-lalrpop-util = "0.15.1"
+lalrpop-util = "0.15"
 
 [dependencies.clippy]
 optional = true


### PR DESCRIPTION
Dropping to 0.15 means that cargo is free to download any 0.15.x
compatible version, rather than being stuck at 0.15.1.

Fixes #17.