### PR TITLE
Bumping lalrpop to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ version = "0.7.0"
 exclude = ["tests/*.zip"]
 
 [build-dependencies]
-lalrpop = "0.15"
+lalrpop = "0.16"
 
 [dependencies]
-lalrpop-util = "0.15"
+lalrpop-util = "0.16"
 
 [dependencies.clippy]
 optional = true


### PR DESCRIPTION
Apparently, lalrpop 0.15.2 has been accidentally packaged with lrgrammar.rs, a multi-megabyte source file that is in fact generated during build... Once again, the Firefox build system refuses such large source files in the vendor repo, so here we are, again :)

Version 0.16 apparently doesn't have this problem anymore, so bumping dependency.

