### PR TITLE
added empty object default value

### DIFF
--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -229,7 +229,8 @@ Default: Option<ast::DefaultValue> = {
 DefaultValue: ast::DefaultValue = {
     ConstValue => ast::DefaultValue::ConstValue(<>),
     "StringLiteral" => ast::DefaultValue::StringLiteral(<>),
-    "[" "]" => ast::DefaultValue::EmptySequence
+    "[" "]" => ast::DefaultValue::EmptySequence,
+    "{" "}" => ast::DefaultValue::EmptySequence
 };
 
 Definition: ast::Definition = {


### PR DESCRIPTION
adding support for parsing default argument value object
```idl
interface mixin HTMLOrSVGElement {
  [SameObject] readonly attribute DOMStringMap dataset;
  attribute DOMString nonce; // intentionally no [CEReactions]

  [CEReactions] attribute boolean autofocus;
  [CEReactions] attribute long tabIndex;
  undefined focus(optional FocusOptions options = {}); // allow {}
  undefined blur();
};
```